### PR TITLE
Fix floating point precision error when rounding

### DIFF
--- a/portfolio_rebalancing.py
+++ b/portfolio_rebalancing.py
@@ -8,22 +8,24 @@ from settings import BINANCE_ORDER_MIN, PAIRING, WAIT_SECONDS_BETWEEN_ORDERS
 def rebalance(balances, required_weights):
     required_changes = _get_required_changes_in_portfolio(required_weights)
 
-    for change in required_changes:
-        symbol = f'{change[0]}{PAIRING}'
+    for symbol, value, change in required_changes:
+        pair = f'{symbol}{PAIRING}'
 
-        if symbol == f'{PAIRING}{PAIRING}':
+        if pair == f'{PAIRING}{PAIRING}':
             continue
 
-        stepsize = get_exchange_stepsize(symbol)
-        quantity = round(change[2] / stepsize) * stepsize
-        if quantity < 0 and -quantity > balances[change[0]]:
-            quantity = math.ceil(change[2] / stepsize) * stepsize
+        stepsize = get_exchange_stepsize(pair)
+        quantity = round(change, int(-math.log10(stepsize)))
+        if symbol in balances and quantity < 0 and -quantity > balances[symbol]:
+            quantity += stepsize
 
-        if change[1] < -BINANCE_ORDER_MIN:
-            create_order(symbol, 'sell', -quantity)
+        value *= quantity / change
+
+        if value < -BINANCE_ORDER_MIN:
+            create_order(pair, 'sell', -quantity)
             time.sleep(WAIT_SECONDS_BETWEEN_ORDERS)
-        elif change[1] > BINANCE_ORDER_MIN:
-            create_order(symbol, 'buy', quantity)
+        elif value > BINANCE_ORDER_MIN:
+            create_order(pair, 'buy', quantity)
             time.sleep(WAIT_SECONDS_BETWEEN_ORDERS)
 
 


### PR DESCRIPTION
This pull request reverts the rounding to the previous method, because the new method could result in floating point precision errors. Instead of rounding again when the selling amount is greater than the balance, it just reduces the selling amount by one step, which has the same effect. Finally, the order value is updated to reflect the actual change instead of the required change.

The `quantity < 0` part on line 19 shouldn't be necessary, because the balance can't be a negative number, but I've kept it there because I think that you've added it to be more explicit. I've opted to unpack `required_changes` for readability, but you can edit it to fit your code style.

As a side note, I'm working on some new features, like redeeming flexible earnings positions before rebalancing, and converting dust to BNB afterwards. I've already used it a few times, but I've not cleaned up the code yet. I'm not sure if these features are a good fit for your more minimalist approach.